### PR TITLE
Add setHighlightRanges support for JetBrains IDE

### DIFF
--- a/packages/cursorless-jetbrains/src/ide/JetbrainsClient.ts
+++ b/packages/cursorless-jetbrains/src/ide/JetbrainsClient.ts
@@ -11,4 +11,5 @@ export interface JetbrainsClient {
   revealLine(editorId: string, line: number, revealAt: string): void;
   readQuery(filename: string): string | undefined;
   flashRanges(flashRangesJson: string): string | undefined;
+  setHighlightRanges(highlightId: string | undefined, editorId: string, rangesJson: string): void;
 }

--- a/packages/cursorless-jetbrains/src/ide/JetbrainsIDE.ts
+++ b/packages/cursorless-jetbrains/src/ide/JetbrainsIDE.ts
@@ -89,11 +89,13 @@ export class JetbrainsIDE implements IDE {
   }
 
   async setHighlightRanges(
-    _highlightId: string | undefined,
-    _editor: TextEditor,
-    _ranges: GeneralizedRange[],
+    highlightId: string | undefined,
+    editor: TextEditor,
+    ranges: GeneralizedRange[],
   ): Promise<void> {
-    throw Error("setHighlightRanges Not implemented");
+    const editorId = editor.id;
+    const rangesJson = JSON.stringify(ranges);
+    this.client.setHighlightRanges(highlightId, editorId, rangesJson);
   }
 
   async flashRanges(flashDescriptors: FlashDescriptor[]): Promise<void> {


### PR DESCRIPTION
Implements the setHighlightRanges method to enable persistent highlighting functionality in the JetBrains Cursorless integration. We need to do this first and cut a new JS bundle before we make a change in the plugin repository.

- Add setHighlightRanges to JetbrainsClient interface
- Implement the method in JetbrainsIDE class
- Pass highlightId, editorId, and serialized ranges to the client